### PR TITLE
Add story writing timer

### DIFF
--- a/api/src/endpoint/story/updateTimeWritingStory.ts
+++ b/api/src/endpoint/story/updateTimeWritingStory.ts
@@ -1,0 +1,23 @@
+import { Request, Response } from "express";
+import Story from "../../models/story";
+
+module.exports = async (req, res) => {
+  Story.findById(req.params.id, function (err, story) {
+    if (err) {
+      console.log(err);
+      return res.json(err);
+    }
+    if (story === null) {
+      return res.status(404).json("story not found");
+    }
+
+    if (req.body.seconds) {
+        story.timeSpentOnStory = (story.timeSpentOnStory ?? 0) + req.body.seconds;
+    } 
+
+    story.save().then(
+      () => res.json("Update story writing time complete"),
+      (err) => res.status(400).json(err)
+    );
+  });
+}

--- a/api/src/models/story.ts
+++ b/api/src/models/story.ts
@@ -69,6 +69,9 @@ const Story = new Schema(
       createdWithPrompts: {
         type: Boolean,
       },
+      timeSpentOnStory: {
+        type: Number,
+      },
     },
     {
       collection: 'story',

--- a/api/src/routes/story.route.ts
+++ b/api/src/routes/story.route.ts
@@ -36,6 +36,7 @@ let storyRoutes;
   const updateStoryAndCheckGrammar = require("../endpoint/story/updateStoryAndCheckGrammar");
   const averageWordCount = require("../endpoint/story/averageWordCount");
   const getStoriesByDate = require("../endpoint/story/getStoriesByDate");
+  const updateTimeWritingStory = require("../endpoint/story/updateTimeWritingStory");
 
   storyRoutes = makeEndpoints({
     get: {
@@ -53,6 +54,7 @@ let storyRoutes;
       "/updateStoryAndCheckGrammar": updateStoryAndCheckGrammar,
       "/averageWordCount/:studentId": averageWordCount,
       "/getStoriesByDate/:studentId": getStoriesByDate,
+      "/updateTimeWritingStory/:id": updateTimeWritingStory
     },
   });
 })();

--- a/ngapp/src/app/core/models/story.ts
+++ b/ngapp/src/app/core/models/story.ts
@@ -19,4 +19,5 @@ export class Story extends Serializable {
     };
     activeRecording: string;
     createdWithPrompts: boolean = false;
+    timeSpentOnStory: number;
 }

--- a/ngapp/src/app/core/services/story.service.ts
+++ b/ngapp/src/app/core/services/story.service.ts
@@ -117,6 +117,10 @@ export class StoryService {
     return this.http.post(this.baseUrl + "updateFeedbackMarkup/" + id, {feedbackMarkup: feedbackMarkup});
   }
 
+  updateTimeWritingStory(id: string, seconds: number) : Observable<any> {
+    return this.http.post(this.baseUrl + "updateTimeWritingStory/" + id, {seconds: seconds});
+  }
+
   getFeedback(id) : Observable<any> {
     return this.http.get(this.baseUrl + "feedback/" + id);
   }


### PR DESCRIPTION
- Measures the amount of time students spend writing a story
- Features include:
  - new ```timeSpentOnStory``` field in the ```Story``` object (time stored in seconds)
  - Timer "starts" when students make a first edit in their story
  - Timer "ends" when the student changes to another story or leaves the dashboard component
  - Time measured as the difference between two Date.now() values (no actual timer running in the background)
  - Time is added to any previously saved time already logged for a given story

Possible improvements:
- Stop the timer if there has been a lack of writing for X minutes 